### PR TITLE
fix: Fix index access error in summary assignment

### DIFF
--- a/gpt_readme/dir_summary.py
+++ b/gpt_readme/dir_summary.py
@@ -73,7 +73,7 @@ async def run_recursive_summarize(path):
         }
     elif len(sub_file_summaries) == 0 and len(sub_module_summaries) == 1:
         dir_result = {
-            "summary": list(sub_file_summaries.values())[0],
+            "summary": list(sub_module_summaries.values())[0],
             "language": language,
         }
     else:


### PR DESCRIPTION
Corrected the code block that assigns the 'summary' field in 'dir_result'.  Previously, the code attempted to access an item from 'sub_file_summaries'  where it should have been accessing 'sub_module_summaries', leading to an  IndexError when 'sub_file_summaries' was empty.